### PR TITLE
Add markdownify to About bio, role, and organization

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -27,7 +27,7 @@
 
     {{ with .Params.bio }}
       <div class="py-8 text-lg leading-normal">
-        {{ . | markdownify}}
+        {{ . | markdownify }}
       </div>
     {{ end }}
   </div>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -15,11 +15,11 @@
       {{ end }}
       <div class="flex flex-wrap">
         {{ with .Params.role }}
-          <span class="pl-4">{{ . }}</span>
+          <span class="pl-4">{{ . | markdownify}}</span>
         {{ end }}
 
         {{ with .Params.organization }}
-          <a href="{{ .url }}" class="pl-4">{{ .name }}</a>
+          <a href="{{ .url }}" class="pl-4">{{ .name | markdownify}}</a>
         {{ end }}
       </div>
 
@@ -27,7 +27,7 @@
 
     {{ with .Params.bio }}
       <div class="py-8 text-lg leading-normal">
-        {{ . }}
+        {{ . | markdownify}}
       </div>
     {{ end }}
   </div>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -15,7 +15,7 @@
       {{ end }}
       <div class="flex flex-wrap">
         {{ with .Params.role }}
-          <span class="pl-4">{{ . | markdownify}}</span>
+          <span class="pl-4">{{ . | markdownify }}</span>
         {{ end }}
 
         {{ with .Params.organization }}

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -19,7 +19,7 @@
         {{ end }}
 
         {{ with .Params.organization }}
-          <a href="{{ .url }}" class="pl-4">{{ .name | markdownify}}</a>
+          <a href="{{ .url }}" class="pl-4">{{ .name | markdownify }}</a>
         {{ end }}
       </div>
 


### PR DESCRIPTION
In my use case I wanted to use markdown in the About section. Here's a simple addition to enable markdown specified in the front matter to render correctly on the about section/partial used on the webpage.

Example screenshot below demonstrating, bold, italic, line breaks, and strikeout on the `role`, `bio`, and organization `name` fields. Normal text without any markdown is still normal and unaffected.

(By the way, thank you for making and updating this theme!)

![image](https://user-images.githubusercontent.com/7938723/105648128-5b3c6e80-5e6f-11eb-861d-d3f3a87bc357.png)
