### PR TITLE
Add tags to the post metadata component

### DIFF
--- a/layouts/partials/components/post-metadata.html
+++ b/layouts/partials/components/post-metadata.html
@@ -31,4 +31,16 @@
         {{ end }}
     </div>
     {{ end }}
+
+    {{ with .GetTerms "tags" }}
+    <div class="mr-6 my-2">
+        <i class="fas fa-tags mr-1"></i>
+        {{ range $index, $value := . }}
+        {{ if gt $index 0 }}
+        <span>, </span>
+        {{ end -}}
+        <a href="{{ .Permalink }}" class="hover:text-eureka">#{{ .LinkTitle }}</a>
+        {{ end }}
+    </div>
+    {{ end }}
 </div>


### PR DESCRIPTION
Stylistic choice. I thought it might be nice to have the tags visible/clickable for website visitors to see immediately. I added the post's tags (with a hashtag) to the `post-metadata.html` component. Tag icon is from FontAwesome.

From what I can see, this affects 2 locations. Two screenshots below.

Here is what it looks like on the pages widget on the homepage of the example website.
![image](https://user-images.githubusercontent.com/7938723/105649487-1cf67d80-5e76-11eb-9d75-4f40fc7b4a60.png)

Here is what it looks like on the post webpage itself at the top. (The tags are also still at the bottom too.)
![image](https://user-images.githubusercontent.com/7938723/105649557-55965700-5e76-11eb-8823-56d19f7ca32d.png)

Feel free to reject if you don't like the look. No offense taken.