### PR TITLE
Allow to add custom CSS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -59,6 +59,10 @@
 {{- $eurekaJS := resources.Get "js/eureka.js" | minify }}
 <script defer src="{{ $eurekaJS.Permalink }}"></script>
 
+{{ range .Site.Params.custom_css -}}
+  <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}
+
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload"
   href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600;700&family=Noto+Serif+SC:wght@400;600;700&display=swap"


### PR DESCRIPTION
With this simple change you can enable anyone to adjust styles by adding a custom_css array into the params file. Mine looks like this:

```
custom_css = ["css/custom.css"]
```

And then I just add the file into the static directory.

This would be most useful for many people.