### PR TITLE
Auto-update copyright year during hugo builds

### DIFF
--- a/exampleSite/config/_default/config.yaml
+++ b/exampleSite/config/_default/config.yaml
@@ -8,7 +8,7 @@ theme: eureka
 
 paginate: 3
 copyright: >
-  &copy; 2021 <a href="https://www.wangchucheng.com/">C. Wang</a> and <a
+  &copy; {year} <a href="https://www.wangchucheng.com/">C. Wang</a> and <a
   href="https://www.ruiqima.com/">R. Ma</a>
 enableEmoji: true
 enableGitInfo: false


### PR DESCRIPTION
Replace hard-coded 2021 year with "{year}", so that it can be auto-updated during the hugo build process. 

"{year}" is updated in `layouts/partials/footer.html` as seen below with the `replace . "{year}" now.Year` portion of the code.

```
<p class="text-sm text-tertiary-text">{{ with .Site.Copyright }}{{ replace . "{year}" now.Year | safeHTML }} &middot; {{ end }} Powered by the <a href="https://github.com/wangchucheng/hugo-eureka" class="hover:text-eureka">Eureka</a> theme for <a href="https://gohugo.io" class="hover:text-eureka">Hugo</a></p>
```
I believe the footer is the only place where the copyright is shown.