### PR TITLE
Fix utterances color scheme setting in the preferred mode

### DIFF
--- a/layouts/partials/comment/utterances.html
+++ b/layouts/partials/comment/utterances.html
@@ -28,5 +28,8 @@
     if (((storageColorScheme == 'Auto' || storageColorScheme == null) && window.matchMedia("(prefers-color-scheme: dark)").matches) || storageColorScheme == "Dark") {
       document.getElementById('utterances').setAttribute('theme', 'github-dark')
     }
+    if (((storageColorScheme == 'Auto' || storageColorScheme == null) && window.matchMedia("(prefers-color-scheme: light)").matches) || storageColorScheme == "Light") {
+      document.getElementById('utterances').setAttribute('theme', 'github-light')
+    }
   {{- end }}
 </script>


### PR DESCRIPTION
Reviously we set utterances' theme to `preferred-color-scheme`
under `eureka` theme. It means using the browser default color
scheme. It's fine if the default was light mode as we have
logic to switch dark mode. However, if the deafult was the dark
mode, utterances won't change its theme even if light mode is
explicity turned on for the website. This commit fixes it.