### PR TITLE
Apply better style for taxonomy terms

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,4 +1,9 @@
 {{ define "main" }}
+
+{{ $kind := .Data.Plural }}
+{{ $terms := .Data.Terms.ByCount }}
+
+
 <article class="mx-6 my-8">
     <h1 class="font-bold text-3xl text-primary-text">{{ .Title }}</h1>
     {{ with .Content }}
@@ -7,11 +12,23 @@
     </div>
     {{ end }}
 </article>
-<div class="bg-secondary-bg rounded px-6 py-8">
-    {{ range .Pages }}
-    <h2 class="text-lg text-primary-text my-2">
-        <a href="{{ .Permalink }}" class="text-eureka hover:underline">{{ .LinkTitle }}</a>
-    </h2>
-    {{ end }}
+
+<div class="bg-secondary-bg rounded px-6 py-8 text-center">
+  <div class="my-4">
+      {{ range $index, $value := $terms }}
+      <a href="{{ $value.Term | urlize }}" class="inline-block bg-tertiary-bg text-sm rounded px-3 py-1 my-1 mr-2 hover:text-eureka">
+        {{ if eq $kind "tags" }}
+          <i class="fas fa-tags mr-1"></i>
+        {{ else if eq $kind "series" }}
+          <i class="fas fa-th-list mr-1"></i>
+        {{ else if eq $kind "categories" }}
+          <i class="fas fa-folder mr-1"></i>
+        {{ end }}
+        {{ $value.Term }}
+        <sup>{{ len $value.Pages }}</sup>
+      </a>
+      {{ end }}
+  </div>
 </div>
 {{ end }}
+


### PR DESCRIPTION
- Grouped terms like a cloud instead of scattering each term on
  its own line
- Used a leading icon to make different taxonomy kinds
  distinguishable
- Also showed the page count matching each term as superscript

Fixes https://github.com/wangchucheng/hugo-eureka/issues/125